### PR TITLE
Disable upload button to prevent multiple progress bars.

### DIFF
--- a/app/static/js/fileupload.js
+++ b/app/static/js/fileupload.js
@@ -4,6 +4,7 @@
             event.preventDefault();
             let formData = new FormData();
             let files = $('#fileInput')[0].files;
+             $("input[type=submit]")[0].disabled  = true;
 
             if (files.length!==0) {
                 let progressBar = `
@@ -43,6 +44,7 @@
 
                 $('#modalDialog').append(modal);
                 modal.modal('show');
+                $("input[type=submit]")[0].disabled  = false;
             }
 
             // Single Axios API call for all files with progress tracking


### PR DESCRIPTION
This commit disables upload button during file upload to prevent multiple progress bars from appearing.
see- https://drive.google.com/file/d/150nhAn5Zvae74E3SjQdoasx-ZlACTY_h/view?usp=drive_link